### PR TITLE
Add profile detection features

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ localhost                  : ok=5    changed=0    unreachable=0    failed=0
 
 ## Release Notes
 
+### Version 1.1
+
+- Add profile detection feature
+
 ### Version 1.0
 
 - Switch to dot notation syntax

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ localhost                  : ok=5    changed=0    unreachable=0    failed=0
 
 ## Release Notes
 
-### Version 1.1
+### Version 2.4.0
 
+- Ansible 2.4 support
 - Add profile detection feature
 
 ### Version 1.0

--- a/README.md
+++ b/README.md
@@ -68,14 +68,11 @@ $ git commit -a -m "Updated to aws-sts 0.2.0 role"
 
 The STS role relies on a top level `Sts` object that uses the following inputs:
 
-- `Sts.Role` (Mandatory) - this variable must be provided by the calling playbook, representing the ARN of the role to assume
-
+- `Sts.Profile` (Conditional) - defines the local AWS profile that credentials should be obtained from.
+- `Sts.Role` (Optional) - defines the ARN of the role to assume.  If configured, this will override the role associated with the detected/configured profile.
 - `Sts.SessionName` (Optional) - a name for the temporary session token that is generated
-
-- `Sts.Disabled` (Optional) - disables all actions of this role.  Useful for long running playbooks that would be affected by the duration (maximum 60 minutes) of using STS token.
-
-- `Sts.Region` (Optional) - the target AWS region.  Alternatively you can set the AWS region using the `AWS_DEFAULT_REGION` environment variable.  If this is not in your environment, the playbook defaults to `ap-southeast-2`.
-
+- `Sts.Disabled` (Optional) - disables the assume role action of this role.  Useful for long running playbooks that would be affected by the duration (maximum 60 minutes) of using STS token.  You must set this flag whenever you use explicit AWS credentials in your local environment (e.g. you have configured access key, secret access key and session token as environment variables) and **you don't want to attempt to assume a role**.
+- `Sts.Region` (Optional) - the target AWS region.  Alternatively you can set the AWS region using the `AWS_DEFAULT_REGION` environment variable.  If this is not in your environment, the playbook defaults to `us-west-2`.
 - AWS credentials - you must configure the environment such that your credentials are available to assume the role.  For example, you can set an access key and secret key via environment variables, or configure a profile via environment variables, or rely on an EC2 instance profile if running in AWS.  A dictionary called `Sts.Credentials` is output by this module, which sets up the appropriate configuration with AWS STS token settings.
 
 ### Outputs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,12 @@
   - name: create sts variable
     set_fact:
       Sts: "{{ Sts | default({}) | combine((vars['hostvars'][env] | dotted_dict(paths=['Sts.'])).get('Sts') or {}, recursive=True) }}"
-
   - set_fact:
       sts_region: "{{ Sts.Region
         | default(lookup('env', 'AWS_DEFAULT_REGION')) 
         | default('us-west-2', true) }}"
   - set_fact:
-      Sts: "{{ Sts | combine({'Region': sts_region},recursive=True) }}"
+      Sts: "{{ Sts | combine({'Region': sts_region, 'Profile': Sts.Profile | default(lookup('env','AWS_PROFILE'))},recursive=True) }}"
   tags:
     - always
 
@@ -24,20 +23,29 @@
     set_fact:
       sts_creds:
         AWS_DEFAULT_REGION: "{{ sts_region }}"
-        AWS_ACCESS_KEY: "{{ lookup('env','AWS_ACCESS_KEY') }}"
-        AWS_ACCESS_KEY_ID: "{{ lookup('env','AWS_ACCESS_KEY') }}"
-        AWS_SECRET_KEY: "{{ lookup('env','AWS_SECRET_KEY') }}"
-        AWS_SECRET_ACCESS_KEY: "{{ lookup('env','AWS_SECRET_KEY') }}"
-    when: lookup('env','AWS_ACCESS_KEY') and lookup('env','AWS_SECRET_KEY')
+        AWS_ACCESS_KEY: "{{ lookup('env','AWS_ACCESS_KEY_ID') | default(lookup('env','AWS_ACCESS_KEY')) }}"
+        AWS_ACCESS_KEY_ID: "{{ lookup('env','AWS_ACCESS_KEY_ID') | default(lookup('env','AWS_ACCESS_KEY')) }}"
+        AWS_SECRET_KEY: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') | default(lookup('env', 'AWS_SECRET_KEY')) }}"
+        AWS_SECRET_ACCESS_KEY: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') | default(lookup('env', 'AWS_SECRET_KEY')) }}"
+    when: (lookup('env','AWS_ACCESS_KEY') or lookup('env','AWS_ACCESS_KEY_ID')) and (lookup('env','AWS_SECRET_KEY') or lookup('env', 'AWS_SECRET_ACCESS_KEY'))
   when: Sts.Disabled | default(false) | bool
   tags:
     - always
 
 - block:
+  - name: get sts role from profile
+    shell: aws configure get role_arn --profile {{ Sts.Profile }}
+    changed_when: False
+    register: sts_role_output
+    when: Sts.Profile
+  - set_fact:
+      Sts: "{{ Sts | combine({'Role': Sts.Role | default(sts_role_output.stdout)},recursive=True) }}"
+    when: Sts.Profile is defined
   - name: assume sts role
     environment:
       AWS_DEFAULT_REGION: "{{ Sts.Region }}"
     shell: aws sts assume-role
+      {{ '--profile=' + Sts.Profile if Sts.Profile else '' }}
       --role-arn="{{ Sts.Role }}"
       --role-session-name="{{ Sts.SessionName | default('adminSession') }}"
     changed_when: False
@@ -50,6 +58,7 @@
         AWS_ACCESS_KEY_ID: "{{ (sts_session_output.stdout | from_json)['Credentials']['AccessKeyId'] }}"
         AWS_SECRET_KEY: "{{ (sts_session_output.stdout | from_json)['Credentials']['SecretAccessKey'] }}"
         AWS_SECRET_ACCESS_KEY: "{{ (sts_session_output.stdout | from_json)['Credentials']['SecretAccessKey'] }}"
+        AWS_SESSION_TOKEN: "{{ (sts_session_output.stdout | from_json)['Credentials']['SessionToken'] }}"
         AWS_SECURITY_TOKEN: "{{ (sts_session_output.stdout | from_json)['Credentials']['SessionToken'] }}"
   when: not Sts.Disabled | default(false) | bool
   tags:
@@ -62,8 +71,10 @@
   tags:
     - always
 
-- debug: msg={{ sts_session_output }}
+- block:
+  - debug: msg={{ sts_session_output }}
+  - name: Sts.Credentials variable
+    debug: msg={{ Sts.Credentials }}
   when: debug | default(false) | bool
   tags:
     - always
-


### PR DESCRIPTION
This PR introduces profile detection features with the following behaviour:

- You don't need to explicitly set the role using the `Sts.Role` setting.  The role will now detect this from the configured profile using either the `Sts.Profile` setting or from the local environment variable `AWS_PROFILE`.
- You can explicitly define an AWS CLI profile using the `Sts.Profile` setting.
- By default, the role will attempt to assume the role defined with the CLI profile.  An explicit role to assume can still be defined using `Sts.Role` which will override the detected role associated with the CLI profile.

Typical usage now is that the user does not need to define any Sts settings and simply sets an appropriate profile in the environment:

```
$ export AWS_PROFILE=casecommons-admin
$ make deploy/dev
...
...
```

  